### PR TITLE
ci: switch to the ioio-k8s-police-appointment-times ARC runner scale set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,9 @@ concurrency:
 jobs:
   release:
     name: Release
-    runs-on: self-hosted
+    # Modern ARC scale sets have no runner labels: runs-on must be exactly
+    # the scale set name (see ioio clusters/baremetal/actions-runners/).
+    runs-on: ioio-k8s-police-appointment-times
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -29,9 +31,17 @@ jobs:
             - 'frontend/**'
 
     - # Setting up Docker Buildx with docker-container driver is required
-      # at the moment to be able to use a subdirectory with Git context
+      # at the moment to be able to use a subdirectory with Git context.
+      # Host networking on both levels: the runner pod network MTU is 1480
+      # and buildkit's default bridged networks assume 1500 — large
+      # downloads inside RUN steps black-hole otherwise.
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver-opts: network=host
+        buildkitd-config-inline: |
+          [worker.oci]
+            networkMode = "host"
 
     - name: Log in to the Container registry
       uses: docker/login-action@v2


### PR DESCRIPTION
Part of the homelab runner migration to modern ARC (gha-runner-scale-set): scale sets have no runner labels, so `runs-on: self-hosted` no longer matches anything — the new target is the scale set name `ioio-k8s-police-appointment-times`. Also bumps setup-buildx to v3 with host networking (pod MTU is 1480; buildkit's bridged defaults black-hole large downloads). codeql.yml is untouched (GitHub-hosted matrix incl. macos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bymem2hyFQ8XbYHw3SNKRF